### PR TITLE
Add available memory checks

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -241,19 +241,20 @@ prerequisite() {
   fi
 
   # check if kuzzle has enough ram
-  free_ram=$(free -m | grep Mem | awk '{ print $7 }')
-  free_swap=$(free -m | grep Swap | awk '{ print $4 }')
-  let free_total=$free_ram+$free_swap
-  echo $free_total
+  if [ "$OS" != "OSX" ]; then
+    free_ram=$(grep MemAvailable /proc/meminfo | awk '{ print $2 }')
+    free_swap=$(grep SwapFree /proc/meminfo | awk '{ print $2 }')
+    let free_total=$free_ram+$free_swap
 
-  if [ $free_total -lt 1400 ]; then
-    write_error
-    write_error "[✖] Not enough memory available to run Kuzzle."
-    write_error "    Kuzzle needs at least 1.4GB of free memory."
-    write_error "    Please consider quitting one or more applications to increase available memory, and then try again."
-    echo
-    $KUZZLE_PUSH_ANALYTICS'{"type": "'$EVENT_OUT_OF_MEMORY'", "uid": "'$ANALYTICS_UUID'", "os": "'$OS'"}' $ANALYTICS_URL &> /dev/null
-    ERROR=$MISSING_DEPENDENCY
+    if [ $free_total -lt 1433600 ]; then
+      write_error
+      write_error "[✖] Not enough memory available to run Kuzzle."
+      write_error "    Kuzzle needs at least 1.4GB of free memory."
+      write_error "    Please consider quitting one or more applications to increase available memory, and then try again."
+      echo
+      $KUZZLE_PUSH_ANALYTICS'{"type": "'$EVENT_OUT_OF_MEMORY'", "uid": "'$ANALYTICS_UUID'", "os": "'$OS'"}' $ANALYTICS_URL &> /dev/null
+      ERROR=$MISSING_DEPENDENCY
+    fi
   fi
 
   # Check if sysctl exists on the machine

--- a/setup.sh
+++ b/setup.sh
@@ -54,6 +54,7 @@ EVENT_ABORT_SETUP=abort-setup
 EVENT_MISSING_DOCKER=missing-docker
 EVENT_MISSING_DOCKER_COMPOSE=missing-docker-compose
 EVENT_DOCKER_VERSION_MISMATCH=docker-version-mismatch
+EVENT_OUT_OF_MEMORY=out-of-memory
 EVENT_MISSING_SYSCTL=missing-sysctl
 EVENT_WRONG_MAX_MAP_COUNT=wrong-max_map_count
 EVENT_ERR_DL_DOCKER_COMPOSE_YML=error-download-dockercomposeyml
@@ -239,9 +240,25 @@ prerequisite() {
     fi
   fi
 
+  # check if kuzzle has enough ram
+  free_ram=$(free -m | grep Mem | awk '{ print $7 }')
+  free_swap=$(free -m | grep Swap | awk '{ print $4 }')
+  let free_total=$free_ram+$free_swap
+  echo $free_total
+
+  if [ $free_total -lt 1400 ]; then
+    write_error
+    write_error "[✖] Not enough memory available to run Kuzzle."
+    write_error "    Kuzzle needs at least 1.4GB of free memory."
+    write_error "    Please consider quitting one or more applications to increase available memory, and then try again."
+    echo
+    $KUZZLE_PUSH_ANALYTICS'{"type": "'$EVENT_OUT_OF_MEMORY'", "uid": "'$ANALYTICS_UUID'", "os": "'$OS'"}' $ANALYTICS_URL &> /dev/null
+    ERROR=$MISSING_DEPENDENCY
+  fi
+
   # Check if sysctl exists on the machine
   if [ "$OS" != "OSX" ]; then
-    if ! command_exists sysctl; then
+    if ! command_exists /sbin/sysctl; then
       write_error "[✖] This script needs sysctl to check that your kernel settings meet the Kuzzle requirements."
       write_error "    Please install sysctl and re-run this script."
       echo
@@ -249,7 +266,7 @@ prerequisite() {
       ERROR=$MISSING_DEPENDENCY
     else
       # Check of vm.max_map_count is at least $MIN_MAX_MAP_COUNT
-      VM_MAX_MAP_COUNT=$(sysctl -n vm.max_map_count)
+      VM_MAX_MAP_COUNT=$(/sbin/sysctl -n vm.max_map_count)
       if [ -z "${VM_MAX_MAP_COUNT}" ] || [ ${VM_MAX_MAP_COUNT} -lt $MIN_MAX_MAP_COUNT ]; then
         write_error
         write_error "[✖] The current value of the kernel configuration variable vm.max_map_count (${VM_MAX_MAP_COUNT})"


### PR DESCRIPTION
When the system is short on memory, the setup.sh tries to launch the complete stack, which silently fails. The user is then informed Kuzzle is not running after it timed out.

This PR adds some checks to prevent trying to launch Kuzzle is not enough memory is available.

NB: the limit of 1400MB has been set considering the existing docker-compose stack (which uses 1GB of heap space for elasticsearch only) and by tweaking the memory usage using a ram disk.

### Other changes:

The setup.sh needs to be run as sudo just because sysctl is in /sbin, which is not included in regular users' path.
Once this PR is merged, we can update the website to run the script as non-privileged user.